### PR TITLE
Add Docker Compose Configuration for Notification Service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -174,3 +174,15 @@ services:
       - postgres-inventory-service
       - discovery-server
       - api-gateway
+
+  ## Notification-Service Docker Compose Config
+  notification-service:
+    image: aamirxshaikh/notification-service:latest
+    container_name: notification-service
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+    depends_on:
+      - zipkin
+      - kafka
+      - discovery-server
+      - api-gateway


### PR DESCRIPTION
### Description:
This pull request introduces changes to the Docker Compose configuration to include the `notification-service` in the application deployment.

### Changes:
- **Notification Service Configuration:** Add a new service configuration for the `notification-service` in the `docker-compose.yaml` file.
- **Docker Image:** Set the Docker image for the notification service to `aamirxshaikh/notification-service:latest`.
- **Container Name:** Set the container name for the notification service to `notification-service`.
- **Active Profile:** Configure the `SPRING_PROFILES_ACTIVE` environment variable to `docker` for the notification service.
- **Service Dependencies:** Make the notification service dependent on the `zipkin`, `kafka`, `discovery-server`, and `api-gateway` services.

### Purpose:
The purpose of this pull request is to include the `notification-service` in the Docker Compose configuration. By adding the service configuration to the `docker-compose.yaml` file, the notification service can be easily deployed and managed alongside the other microservices in the application. The commit configures the necessary settings, such as the Docker image, container name, active profile, and service dependencies, to ensure the proper functioning of the notification service within the Docker Compose environment.